### PR TITLE
Split into multiple confirms

### DIFF
--- a/problems/lesson6.code
+++ b/problems/lesson6.code
@@ -17,6 +17,8 @@ Facility BeginToReason;
             K := J;
         end;
 
-        Confirm K /*conditional*/ #I and K /*conditional*/ #J and K /*conditional*/ #K;
+        Confirm K /*conditional*/ #I;
+        Confirm K /*conditional*/ #J;
+        Confirm K /*conditional*/ #K;
     end Main;
 end BeginToReason;

--- a/problems/lesson6.json
+++ b/problems/lesson6.json
@@ -8,11 +8,11 @@
   "nextLessonOnSuccess": "problems/challenge1.json",
   "nextLessonOnFailure": "problems/lesson6.json",
 
-  "learningObjective": "<p>On line 20 choose a relational operator to replace each of the three places where /* conditional */ appears so that the Confirm statement evaluates to true</p>",
+  "learningObjective": "<p>On lines 20, 21, and 22 choose a relational operator to replace /* conditional */ so that the Confirm statements evaluate to true</p>",
 
   "referenceMaterial": "<p><em>Remember statement</em> - Does the following:</p><blockquote><p> At the point in the code where the Remember statement occurs the value of a variable 'x' is assumed to be #x and  this value represented by #x can be referenced in subsequent Confirm statements</p></blockquote><p><em>Relational Operators</em> - There are 5  relational operators from which to choose, they are: </p><blockquote><pre>=   &lt;   &lt;=    &gt;    &gt;=</pre></blockquote>",
 
-  "lines": [20],
+  "lines": [20, 21, 22],
 
-  "checks": [["Confirm K <= #I and K <= #J and K <= #K;"]]
+  "checks": [["Confirm K <= #I;"], ["Confirm K <= #J;"], ["Confirm K <= #K;"]]
 }


### PR DESCRIPTION
Our `JavaScript` check disallows other logical operators. This is the only activity where we have multiple expressions in one `Confirm` statement.

@timschwab 