### PR TITLE
Time in Seconds

### DIFF
--- a/backend/time.js
+++ b/backend/time.js
@@ -6,5 +6,5 @@ function resetTime() {
 
 function getTime() {
     var endTime = new Date();
-    return endTime.getTime() - time.getTime();
+    return Math.round((endTime.getTime() - time.getTime()) / 1000);
 }


### PR DESCRIPTION
We don't really need the millisecond precision when measuring the time spent on each lesson. So rather than storing the time in milliseconds, we store it in seconds. 

@timschwab Can you update the server when you merge this?