### PR TITLE
Random author IDs were too small

### DIFF
--- a/backend/sendData.js
+++ b/backend/sendData.js
@@ -1,6 +1,4 @@
-/* global approved createEditor currentLesson getTime */
-
-var author = Math.floor(Math.random() * 1000000000);
+/* global approved author createEditor currentLesson getTime */
 
 function sendData() {
     var data = {};

--- a/right/javascript/inject.js
+++ b/right/javascript/inject.js
@@ -12,8 +12,8 @@ function injectCreate(id) {
             // Reuse the same author ID
             author = localStorage.getItem("author");
         } else {
-            // Generate a random number from 1 to 10000
-            author = Math.floor(Math.random() * 10000 + 1);
+            // Generate a random number from 1 to 1000000000
+            author = Math.floor(Math.random() * 1000000000);
             localStorage.setItem("author", author);
         }
     });


### PR DESCRIPTION
Our range of random numbers from 1 to 10000 was too small. The chance of duplicates is too high! Now the new range is from 1 to 1000000000. Also, removed an extra `author` value that isn't used at all.

@timschwab Let me know if you see any problems with this.